### PR TITLE
Added rudimentary export/import of data for a param group.

### DIFF
--- a/Yapped/FormMain.Designer.cs
+++ b/Yapped/FormMain.Designer.cs
@@ -53,6 +53,7 @@
             this.findNextFieldToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.importNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.verifyDeletionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -71,6 +72,8 @@
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.fbdExport = new System.Windows.Forms.FolderBrowserDialog();
+            this.importDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
@@ -93,13 +96,14 @@
             // 
             // menuStrip1
             // 
+            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.editToolStripMenuItem,
             this.updateToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(760, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(1013, 30);
             this.menuStrip1.TabIndex = 8;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -115,14 +119,14 @@
             this.toolStripComboBoxGame,
             this.hideUnusedParamsToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 26);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.openToolStripMenuItem.Text = "&Open";
             this.openToolStripMenuItem.ToolTipText = "Browse for a regulation file to edit.";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItem_Click);
@@ -131,7 +135,7 @@
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.saveToolStripMenuItem.Text = "&Save";
             this.saveToolStripMenuItem.ToolTipText = "Save changes to the regulation file.";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
@@ -139,7 +143,7 @@
             // restoreToolStripMenuItem
             // 
             this.restoreToolStripMenuItem.Name = "restoreToolStripMenuItem";
-            this.restoreToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.restoreToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.restoreToolStripMenuItem.Text = "Restore";
             this.restoreToolStripMenuItem.ToolTipText = "Restore the regulation file backup.";
             this.restoreToolStripMenuItem.Click += new System.EventHandler(this.RestoreToolStripMenuItem_Click);
@@ -147,7 +151,7 @@
             // exploreToolStripMenuItem
             // 
             this.exploreToolStripMenuItem.Name = "exploreToolStripMenuItem";
-            this.exploreToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.exploreToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.exploreToolStripMenuItem.Text = "Explore";
             this.exploreToolStripMenuItem.ToolTipText = "Open the regulation file directory in Explorer.";
             this.exploreToolStripMenuItem.Click += new System.EventHandler(this.ExploreToolStripMenuItem_Click);
@@ -155,7 +159,7 @@
             // exportToolStripMenuItem
             // 
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.exportToolStripMenuItem.Text = "Export";
             this.exportToolStripMenuItem.ToolTipText = "Export an encrypted Data0.bdt to decrypted parambnds.";
             this.exportToolStripMenuItem.Click += new System.EventHandler(this.ExportToolStripMenuItem_Click);
@@ -163,13 +167,13 @@
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(181, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(225, 6);
             // 
             // toolStripComboBoxGame
             // 
             this.toolStripComboBoxGame.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.toolStripComboBoxGame.Name = "toolStripComboBoxGame";
-            this.toolStripComboBoxGame.Size = new System.Drawing.Size(121, 23);
+            this.toolStripComboBoxGame.Size = new System.Drawing.Size(121, 28);
             // 
             // hideUnusedParamsToolStripMenuItem
             // 
@@ -177,7 +181,7 @@
             this.hideUnusedParamsToolStripMenuItem.CheckOnClick = true;
             this.hideUnusedParamsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.hideUnusedParamsToolStripMenuItem.Name = "hideUnusedParamsToolStripMenuItem";
-            this.hideUnusedParamsToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.hideUnusedParamsToolStripMenuItem.Size = new System.Drawing.Size(228, 26);
             this.hideUnusedParamsToolStripMenuItem.Text = "Hide Unused Params";
             this.hideUnusedParamsToolStripMenuItem.ToolTipText = "When checked, unused params will not be loaded";
             // 
@@ -194,17 +198,20 @@
             this.findNextFieldToolStripMenuItem,
             this.importNamesToolStripMenuItem,
             this.exportNamesToolStripMenuItem,
+            this.toolStripSeparator3,
+            this.importDataToolStripMenuItem,
+            this.exportDataToolStripMenuItem,
             this.toolStripSeparator1,
             this.verifyDeletionsToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(49, 26);
             this.editToolStripMenuItem.Text = "Edit";
             // 
             // addRowToolStripMenuItem
             // 
             this.addRowToolStripMenuItem.Name = "addRowToolStripMenuItem";
             this.addRowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.addRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.addRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.addRowToolStripMenuItem.Text = "Add Row";
             this.addRowToolStripMenuItem.ToolTipText = "Add a new row to the active param.";
             this.addRowToolStripMenuItem.Click += new System.EventHandler(this.AddRowToolStripMenuItem_Click);
@@ -214,7 +221,7 @@
             this.duplicateRowToolStripMenuItem.Name = "duplicateRowToolStripMenuItem";
             this.duplicateRowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.N)));
-            this.duplicateRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.duplicateRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.duplicateRowToolStripMenuItem.Text = "Duplicate Row";
             this.duplicateRowToolStripMenuItem.ToolTipText = "Create a new row with values identical to the selected one";
             this.duplicateRowToolStripMenuItem.Click += new System.EventHandler(this.DuplicateRowToolStripMenuItem_Click);
@@ -223,7 +230,7 @@
             // 
             this.deleteRowToolStripMenuItem.Name = "deleteRowToolStripMenuItem";
             this.deleteRowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Delete)));
-            this.deleteRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.deleteRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.deleteRowToolStripMenuItem.Text = "Delete Row";
             this.deleteRowToolStripMenuItem.ToolTipText = "Delete the currently selected row";
             this.deleteRowToolStripMenuItem.Click += new System.EventHandler(this.DeleteRowToolStripMenuItem_Click);
@@ -232,7 +239,7 @@
             // 
             this.findRowToolStripMenuItem.Name = "findRowToolStripMenuItem";
             this.findRowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.findRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.findRowToolStripMenuItem.Text = "&Find Row";
             this.findRowToolStripMenuItem.ToolTipText = "Search for a row with a matching name";
             this.findRowToolStripMenuItem.Click += new System.EventHandler(this.FindRowToolStripMenuItem_Click);
@@ -241,7 +248,7 @@
             // 
             this.findNextRowToolStripMenuItem.Name = "findNextRowToolStripMenuItem";
             this.findNextRowToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.findNextRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.findNextRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.findNextRowToolStripMenuItem.Text = "Find Next Row";
             this.findNextRowToolStripMenuItem.ToolTipText = "Search again with the previous pattern";
             this.findNextRowToolStripMenuItem.Click += new System.EventHandler(this.FindNextRowToolStripMenuItem_Click);
@@ -250,7 +257,7 @@
             // 
             this.gotoRowToolStripMenuItem.Name = "gotoRowToolStripMenuItem";
             this.gotoRowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.gotoRowToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.gotoRowToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.gotoRowToolStripMenuItem.Text = "&Goto Row";
             this.gotoRowToolStripMenuItem.ToolTipText = "Go to a row with a certain ID";
             this.gotoRowToolStripMenuItem.Click += new System.EventHandler(this.GotoRowToolStripMenuItem_Click);
@@ -260,7 +267,7 @@
             this.findFieldToolStripMenuItem.Name = "findFieldToolStripMenuItem";
             this.findFieldToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.F)));
-            this.findFieldToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.findFieldToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.findFieldToolStripMenuItem.Text = "Find Field";
             this.findFieldToolStripMenuItem.ToolTipText = "Search for a field with a matching name";
             this.findFieldToolStripMenuItem.Click += new System.EventHandler(this.FindFieldToolStripMenuItem_Click);
@@ -269,7 +276,7 @@
             // 
             this.findNextFieldToolStripMenuItem.Name = "findNextFieldToolStripMenuItem";
             this.findNextFieldToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F3)));
-            this.findNextFieldToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.findNextFieldToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.findNextFieldToolStripMenuItem.Text = "Find Next Field";
             this.findNextFieldToolStripMenuItem.ToolTipText = "Search again with the previous pattern";
             this.findNextFieldToolStripMenuItem.Click += new System.EventHandler(this.FindNextFieldToolStripMenuItem_Click);
@@ -277,7 +284,7 @@
             // importNamesToolStripMenuItem
             // 
             this.importNamesToolStripMenuItem.Name = "importNamesToolStripMenuItem";
-            this.importNamesToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.importNamesToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.importNamesToolStripMenuItem.Text = "Import Names";
             this.importNamesToolStripMenuItem.ToolTipText = "Insert known row names to their corresponding IDs";
             this.importNamesToolStripMenuItem.Click += new System.EventHandler(this.ImportNamesToolStripMenuItem_Click);
@@ -285,15 +292,31 @@
             // exportNamesToolStripMenuItem
             // 
             this.exportNamesToolStripMenuItem.Name = "exportNamesToolStripMenuItem";
-            this.exportNamesToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.exportNamesToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.exportNamesToolStripMenuItem.Text = "Export Names";
             this.exportNamesToolStripMenuItem.ToolTipText = "Export row names from the params to text files";
             this.exportNamesToolStripMenuItem.Click += new System.EventHandler(this.ExportNamesToolStripMenuItem_Click);
             // 
+            // importDataToolStripMenuItem
+            // 
+            this.importDataToolStripMenuItem.Name = "importDataToolStripMenuItem";
+            this.importDataToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
+            this.importDataToolStripMenuItem.Text = "Import Data";
+            this.importDataToolStripMenuItem.ToolTipText = "Import row data from text files to the params";
+            this.importDataToolStripMenuItem.Click += new System.EventHandler(this.ImportDataToolStripMenuItem_Click);
+            // 
+            // exportDataToolStripMenuItem
+            // 
+            this.exportDataToolStripMenuItem.Name = "exportDataToolStripMenuItem";
+            this.exportDataToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
+            this.exportDataToolStripMenuItem.Text = "Export Data";
+            this.exportDataToolStripMenuItem.ToolTipText = "Export row data from the params to text files";
+            this.exportDataToolStripMenuItem.Click += new System.EventHandler(this.ExportDataToolStripMenuItem_Click);
+            // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(222, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(279, 6);
             // 
             // verifyDeletionsToolStripMenuItem
             // 
@@ -301,7 +324,7 @@
             this.verifyDeletionsToolStripMenuItem.CheckOnClick = true;
             this.verifyDeletionsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.verifyDeletionsToolStripMenuItem.Name = "verifyDeletionsToolStripMenuItem";
-            this.verifyDeletionsToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
+            this.verifyDeletionsToolStripMenuItem.Size = new System.Drawing.Size(282, 26);
             this.verifyDeletionsToolStripMenuItem.Text = "Verify Row Deletion";
             this.verifyDeletionsToolStripMenuItem.ToolTipText = "If checked, always ask before deleting a row";
             // 
@@ -310,7 +333,7 @@
             this.updateToolStripMenuItem.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.updateToolStripMenuItem.BackColor = System.Drawing.Color.Yellow;
             this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
-            this.updateToolStripMenuItem.Size = new System.Drawing.Size(57, 20);
+            this.updateToolStripMenuItem.Size = new System.Drawing.Size(72, 26);
             this.updateToolStripMenuItem.Text = "Update";
             this.updateToolStripMenuItem.ToolTipText = "An update is available! Click to download it.";
             this.updateToolStripMenuItem.Visible = false;
@@ -320,7 +343,8 @@
             // 
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 24);
+            this.splitContainer2.Location = new System.Drawing.Point(0, 30);
+            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer2.Name = "splitContainer2";
             // 
             // splitContainer2.Panel1
@@ -330,8 +354,9 @@
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.splitContainer1);
-            this.splitContainer2.Size = new System.Drawing.Size(760, 500);
+            this.splitContainer2.Size = new System.Drawing.Size(1013, 616);
             this.splitContainer2.SplitterDistance = 249;
+            this.splitContainer2.SplitterWidth = 5;
             this.splitContainer2.TabIndex = 2;
             // 
             // dgvParams
@@ -346,10 +371,12 @@
             this.dgvParamsParamCol});
             this.dgvParams.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgvParams.Location = new System.Drawing.Point(0, 0);
+            this.dgvParams.Margin = new System.Windows.Forms.Padding(4);
             this.dgvParams.MultiSelect = false;
             this.dgvParams.Name = "dgvParams";
             this.dgvParams.RowHeadersVisible = false;
-            this.dgvParams.Size = new System.Drawing.Size(249, 500);
+            this.dgvParams.RowHeadersWidth = 51;
+            this.dgvParams.Size = new System.Drawing.Size(249, 616);
             this.dgvParams.TabIndex = 0;
             this.dgvParams.CellToolTipTextNeeded += new System.Windows.Forms.DataGridViewCellToolTipTextNeededEventHandler(this.DgvParams_CellToolTipTextNeeded);
             this.dgvParams.SelectionChanged += new System.EventHandler(this.DgvParams_SelectionChanged);
@@ -358,6 +385,7 @@
             // 
             this.dgvParamsParamCol.DataPropertyName = "Name";
             this.dgvParamsParamCol.HeaderText = "Param";
+            this.dgvParamsParamCol.MinimumWidth = 6;
             this.dgvParamsParamCol.Name = "dgvParamsParamCol";
             this.dgvParamsParamCol.ReadOnly = true;
             // 
@@ -366,6 +394,7 @@
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -375,8 +404,9 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.dgvCells);
-            this.splitContainer1.Size = new System.Drawing.Size(507, 500);
-            this.splitContainer1.SplitterDistance = 250;
+            this.splitContainer1.Size = new System.Drawing.Size(759, 616);
+            this.splitContainer1.SplitterDistance = 499;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 7;
             // 
             // dgvRows
@@ -391,10 +421,12 @@
             this.dgvRowsNameCol});
             this.dgvRows.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgvRows.Location = new System.Drawing.Point(0, 0);
+            this.dgvRows.Margin = new System.Windows.Forms.Padding(4);
             this.dgvRows.MultiSelect = false;
             this.dgvRows.Name = "dgvRows";
             this.dgvRows.RowHeadersVisible = false;
-            this.dgvRows.Size = new System.Drawing.Size(250, 500);
+            this.dgvRows.RowHeadersWidth = 51;
+            this.dgvRows.Size = new System.Drawing.Size(499, 616);
             this.dgvRows.TabIndex = 1;
             this.dgvRows.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.DgvRows_CellValidating);
             this.dgvRows.SelectionChanged += new System.EventHandler(this.DgvRows_SelectionChanged);
@@ -406,14 +438,16 @@
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             this.dgvRowsIDCol.DefaultCellStyle = dataGridViewCellStyle1;
             this.dgvRowsIDCol.HeaderText = "Row";
+            this.dgvRowsIDCol.MinimumWidth = 6;
             this.dgvRowsIDCol.Name = "dgvRowsIDCol";
-            this.dgvRowsIDCol.Width = 54;
+            this.dgvRowsIDCol.Width = 64;
             // 
             // dgvRowsNameCol
             // 
             this.dgvRowsNameCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.dgvRowsNameCol.DataPropertyName = "Name";
             this.dgvRowsNameCol.HeaderText = "Name";
+            this.dgvRowsNameCol.MinimumWidth = 6;
             this.dgvRowsNameCol.Name = "dgvRowsNameCol";
             // 
             // dgvCells
@@ -430,9 +464,11 @@
             this.dgvCells.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgvCells.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
             this.dgvCells.Location = new System.Drawing.Point(0, 0);
+            this.dgvCells.Margin = new System.Windows.Forms.Padding(4);
             this.dgvCells.Name = "dgvCells";
             this.dgvCells.RowHeadersVisible = false;
-            this.dgvCells.Size = new System.Drawing.Size(253, 500);
+            this.dgvCells.RowHeadersWidth = 51;
+            this.dgvCells.Size = new System.Drawing.Size(255, 616);
             this.dgvCells.TabIndex = 2;
             this.dgvCells.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DgvCells_CellFormatting);
             this.dgvCells.CellParsing += new System.Windows.Forms.DataGridViewCellParsingEventHandler(this.DgvCells_CellParsing);
@@ -446,33 +482,38 @@
             this.dgvCellsTypeCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.dgvCellsTypeCol.DataPropertyName = "Type";
             this.dgvCellsTypeCol.HeaderText = "Type";
+            this.dgvCellsTypeCol.MinimumWidth = 6;
             this.dgvCellsTypeCol.Name = "dgvCellsTypeCol";
             this.dgvCellsTypeCol.ReadOnly = true;
-            this.dgvCellsTypeCol.Width = 56;
+            this.dgvCellsTypeCol.Width = 69;
             // 
             // dgvCellsNameCol
             // 
             this.dgvCellsNameCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.dgvCellsNameCol.DataPropertyName = "Name";
             this.dgvCellsNameCol.HeaderText = "Name";
+            this.dgvCellsNameCol.MinimumWidth = 6;
             this.dgvCellsNameCol.Name = "dgvCellsNameCol";
             this.dgvCellsNameCol.ReadOnly = true;
-            this.dgvCellsNameCol.Width = 60;
+            this.dgvCellsNameCol.Width = 74;
             // 
             // dgvCellsValueCol
             // 
             this.dgvCellsValueCol.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.dgvCellsValueCol.DataPropertyName = "Value";
             this.dgvCellsValueCol.HeaderText = "Value";
+            this.dgvCellsValueCol.MinimumWidth = 6;
             this.dgvCellsValueCol.Name = "dgvCellsValueCol";
             // 
             // statusStrip1
             // 
+            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 524);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 646);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(760, 22);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1013, 26);
             this.statusStrip1.SizingGrip = false;
             this.statusStrip1.TabIndex = 9;
             this.statusStrip1.Text = "statusStrip1";
@@ -480,7 +521,7 @@
             // toolStripStatusLabel1
             // 
             this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(81, 17);
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(105, 20);
             this.toolStripStatusLabel1.Text = "No file loaded";
             // 
             // fbdExport
@@ -488,15 +529,21 @@
             this.fbdExport.Description = "Choose the folder to export parambnds to";
             this.fbdExport.RootFolder = System.Environment.SpecialFolder.MyComputer;
             // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(279, 6);
+            // 
             // FormMain
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(760, 546);
+            this.ClientSize = new System.Drawing.Size(1013, 672);
             this.Controls.Add(this.splitContainer2);
             this.Controls.Add(this.menuStrip1);
             this.Controls.Add(this.statusStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "FormMain";
             this.Text = "Yapped <version>";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMain_FormClosing);
@@ -537,10 +584,12 @@
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem addRowToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem deleteRowToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem importNamesToolStripMenuItem;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.ToolStripMenuItem updateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importNamesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportNamesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importDataToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportDataToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn dgvParamsParamCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn dgvRowsIDCol;
         private System.Windows.Forms.DataGridViewTextBoxColumn dgvRowsNameCol;
@@ -563,6 +612,7 @@
         private System.Windows.Forms.ToolStripMenuItem exportToolStripMenuItem;
         private System.Windows.Forms.FolderBrowserDialog fbdExport;
         private System.Windows.Forms.ToolStripComboBox toolStripComboBoxGame;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
     }
 }
 

--- a/Yapped/FormMain.cs
+++ b/Yapped/FormMain.cs
@@ -463,6 +463,11 @@ namespace Yapped
                 return;
             }
 
+            string message = $@"Importing will overwrite {paramName} data. Continue?";
+            DialogResult answer = MessageBox.Show(message, "Import Data", MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation);
+            if (answer == DialogResult.No)
+                return;
+
             dgvRows.Rows.Clear();
 
             StreamReader reader = null;

--- a/Yapped/FormMain.cs
+++ b/Yapped/FormMain.cs
@@ -465,7 +465,18 @@ namespace Yapped
 
             dgvRows.Rows.Clear();
 
-            var reader = new StreamReader(File.OpenRead(paramPath));
+            StreamReader reader = null;
+
+            try
+            {
+                reader = new StreamReader(File.OpenRead(paramPath));
+            }
+            catch (Exception ex)
+            {
+                Util.ShowError($"Failed to open {paramFile}.\r\n\r\n{ex}");
+                return;
+            }
+
             // ignore the headers
             _ = reader.ReadLine();
 


### PR DESCRIPTION
This is my first exposure to .NET and C#, so my code might stink a bit, or a lot. 😄 I have no idea how to test stuff in .NET, so there aren't any. 😞 I don't know if you even want this functionality in Yapped, but hey, here it is. 😉 

I'm working on a mod that revolves around mass changes to virtually all equipment, and while I very much appreciate what Yapped provides, being able to edit only a single value at a time for a single piece of equipment was getting way too tedious. With these changes, I can export all settings for all items in a param group, load it into a spreadsheet app, make mods, and import it back in. I tested it by loading up a heavily modded Data0.bdt, exporting my changes, then opening the vanilla Data0.bdt, and importing my edits. Seems to work fine. The game loaded and ran fine, and what I expected to be there was.

If you like the idea but not the implementation, feel free to make whatever modifications you want. You know Yapped and SoulsFormats so much better than I do, and my feelings won't get hurt in the slightest. Shoot, even if you don't want to incorporate these changes at all, I get it. Yapped is your baby. I can relate. 😄 

Cheers for a great project!

P.S. I don't know where all of those size changes in FormMain.Designer.cs came from. Completely inadvertent. Sorry! Must be something with screen geometry, I guess. 🤷‍♂ 